### PR TITLE
3 home いま話題のアイディアの右のカードのみデザインが異なる

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,14 +46,21 @@ export default function LandingPage() {
 
             <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4 animate-in fade-in slide-in-from-bottom-4 duration-700 delay-300">
               <Link href="/post">
-                <Button size="lg" className="rounded-full gap-2 text-base px-8 h-14 gradient-amber hover:opacity-90 shadow-xl shadow-amber-500/25 transition-all hover:scale-105">
+                <Button
+                  size="lg"
+                  className="rounded-full gap-2 text-base px-8 h-14 gradient-amber hover:opacity-90 shadow-xl shadow-amber-500/25 transition-all hover:scale-105"
+                >
                   <Lightbulb className="h-5 w-5" />
                   不満・アイディアを投稿する
                   <ArrowRight className="h-4 w-4" />
                 </Button>
               </Link>
               <Link href="/ideas">
-                <Button variant="outline" size="lg" className="rounded-full text-base px-8 h-14">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="rounded-full text-base px-8 h-14"
+                >
                   みんなのアイディアを見る
                 </Button>
               </Link>
@@ -66,8 +73,12 @@ export default function LandingPage() {
                 { value: "42", label: "生まれたプロトタイプ" },
               ].map((stat) => (
                 <div key={stat.label} className="text-center">
-                  <div className="text-2xl font-black gradient-text">{stat.value}</div>
-                  <div className="text-xs text-muted-foreground mt-1">{stat.label}</div>
+                  <div className="text-2xl font-black gradient-text">
+                    {stat.value}
+                  </div>
+                  <div className="text-xs text-muted-foreground mt-1">
+                    {stat.label}
+                  </div>
                 </div>
               ))}
             </div>
@@ -93,14 +104,17 @@ export default function LandingPage() {
                 共感を集めている最新の不満・アイディアをチェック
               </p>
             </div>
-            <Link href="/ideas" className="hidden sm:flex items-center gap-1 text-sm font-medium text-amber-600 dark:text-amber-400 hover:underline">
+            <Link
+              href="/ideas"
+              className="hidden sm:flex items-center gap-1 text-sm font-medium text-amber-600 dark:text-amber-400 hover:underline"
+            >
               すべて見る <ChevronRight className="h-4 w-4" />
             </Link>
           </div>
 
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {visibleIdeas.map((idea, i) => (
-              <IdeaCard key={idea.id} idea={idea} masked={!showAllTrending && i >= 2} index={i} />
+              <IdeaCard key={idea.id} idea={idea} masked={false} index={i} />
             ))}
           </div>
 
@@ -124,14 +138,19 @@ export default function LandingPage() {
       <section className="py-24 px-4 sm:px-6 text-center">
         <div className="max-w-2xl mx-auto">
           <h2 className="text-4xl sm:text-5xl font-black tracking-tight">
-            あなたの<span className="gradient-text">アイディアの種</span>を<br />シェアしよう
+            あなたの<span className="gradient-text">アイディアの種</span>を
+            <br />
+            シェアしよう
           </h2>
           <p className="mt-4 text-muted-foreground text-lg">
             AIがあなたのアイディアの言語化をサポートします。まずは気軽に話しかけてみてください。
           </p>
           <div className="mt-8">
             <Link href="/post">
-              <Button size="lg" className="rounded-full gap-2 text-base px-10 h-14 gradient-amber hover:opacity-90 shadow-xl shadow-amber-500/25 transition-all hover:scale-105">
+              <Button
+                size="lg"
+                className="rounded-full gap-2 text-base px-10 h-14 gradient-amber hover:opacity-90 shadow-xl shadow-amber-500/25 transition-all hover:scale-105"
+              >
                 <Sparkles className="h-5 w-5" />
                 無料で始める
               </Button>
@@ -143,15 +162,33 @@ export default function LandingPage() {
   );
 }
 
-function IdeaCard({ idea, masked, index }: { idea: MockIdea; masked: boolean; index: number }) {
+function IdeaCard({
+  idea,
+  index,
+}: {
+  idea: MockIdea;
+  masked: boolean;
+  index: number;
+}) {
   return (
-    <Card className={`overflow-hidden card-hover grain-overlay animate-in fade-in slide-in-from-bottom-4 duration-500 ${masked ? "mask-blur" : ""}`} style={{ animationDelay: `${index * 100}ms` }}>
-      <div className="p-5">
-        <h3 className="font-bold text-lg leading-snug line-clamp-2 mb-3">{idea.title}</h3>
-        <p className="text-sm text-muted-foreground line-clamp-3 leading-relaxed">{idea.content}</p>
+    <Card
+      className={`overflow-hidden card-hover grain-overlay animate-in fade-in slide-in-from-bottom-4 duration-500 `}
+      style={{ animationDelay: `${index * 100}ms` }}
+    >
+      <div className="p-5 flex-1">
+        <h3 className="font-bold text-lg leading-snug line-clamp-2 mb-3">
+          {idea.title}
+        </h3>
+        <p className="text-sm text-muted-foreground line-clamp-3 leading-relaxed">
+          {idea.content}
+        </p>
         <div className="flex flex-wrap gap-1.5 mt-3">
           {idea.tags.map((tag) => (
-            <Badge key={tag} variant="outline" className="text-xs rounded-full bg-transparent">
+            <Badge
+              key={tag}
+              variant="outline"
+              className="text-xs rounded-full bg-transparent"
+            >
               {tag}
             </Badge>
           ))}
@@ -160,9 +197,13 @@ function IdeaCard({ idea, masked, index }: { idea: MockIdea; masked: boolean; in
       <div className="flex items-center justify-between px-5 py-3 border-t bg-muted/30">
         <div className="flex items-center gap-2">
           <Avatar className="h-6 w-6">
-            <AvatarFallback className="text-[10px] bg-amber-100 text-amber-700">{idea.author.avatar}</AvatarFallback>
+            <AvatarFallback className="text-[10px] bg-amber-100 text-amber-700">
+              {idea.author.avatar}
+            </AvatarFallback>
           </Avatar>
-          <span className="text-xs text-muted-foreground">{idea.author.name}</span>
+          <span className="text-xs text-muted-foreground">
+            {idea.author.name}
+          </span>
         </div>
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card pt-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className,
       )}
       {...props}
@@ -84,7 +84,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-6 group-data-[size=sm]/card:p-3",
         className,
       )}
       {...props}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Card({
   className,
@@ -12,12 +12,12 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
-        className
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -26,11 +26,11 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-header"
       className={cn(
         "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -39,11 +39,11 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-title"
       className={cn(
         "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -53,7 +53,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -62,11 +62,11 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-action"
       className={cn(
         "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -76,7 +76,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -85,11 +85,11 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-footer"
       className={cn(
         "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -100,4 +100,4 @@ export {
   CardAction,
   CardDescription,
   CardContent,
-}
+};


### PR DESCRIPTION
変更内容
1. グラデーションの除去（page.tsx）
`masked={!showAllTrending && i >= 2} `で3枚目のカードだけに `mask-blur`（下部グラデーション）が適用されていた。`masked={false}` に変更し全カードのデザインを統一。

2. フッター位置のズレ修正（page.tsx）
グリッドでカードの高さが揃う際、コンテンツが上部に固まりフッター（著者・いいね数）が離れて見えた。コンテンツ`div`に `flex-1` を追加し、フッターが常にカード下部に固定されるよう修正。

