### PR TITLE
fix ホームのカードからhover:cursor-pointerを削除

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -172,7 +172,7 @@ function IdeaCard({
 }) {
   return (
     <Card
-      className={`overflow-hidden card-hover grain-overlay animate-in fade-in slide-in-from-bottom-4 duration-500`}
+      className={`overflow-hidden grain-overlay animate-in fade-in slide-in-from-bottom-4 duration-500`}
       style={{ animationDelay: `${index * 100}ms` }}
     >
       <div className="p-5 flex-1">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -172,7 +172,7 @@ function IdeaCard({
 }) {
   return (
     <Card
-      className={`overflow-hidden card-hover grain-overlay animate-in fade-in slide-in-from-bottom-4 duration-500 hover:cursor-pointer`}
+      className={`overflow-hidden card-hover grain-overlay animate-in fade-in slide-in-from-bottom-4 duration-500`}
       style={{ animationDelay: `${index * 100}ms` }}
     >
       <div className="p-5 flex-1">


### PR DESCRIPTION
## Summary
- ホームページのカードに `hover:cursor-pointer` が設定されていたが、カードをクリックしても詳細ページへ遷移しないため削除

## Test plan
- [x] ホームページのカードにホバーした際、ポインターカーソルが表示されないことを確認

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)