### PR TITLE
feat アイデア詳細ページにNeed度を表示する

### DIFF
--- a/src/app/ideas/[id]/page.tsx
+++ b/src/app/ideas/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { mockIdeas, mockComments, mockPrototypes, MockIdea } from "@/lib/mock-data";
+import { mockIdeas, mockComments, mockPrototypes } from "@/lib/mock-data";
 import { formatDate } from "@/lib/utils";
 import {
   Heart,
@@ -33,6 +33,7 @@ import {
   ArrowLeft,
   Reply,
   X,
+  Star,
 } from "lucide-react";
 
 interface ProtoComment {
@@ -292,6 +293,26 @@ export default function IdeaDetailPage() {
 
           {/* Sidebar */}
           <div className="space-y-4">
+            <Card className="p-5 grain-overlay">
+              <h3 className="font-bold text-sm mb-2">Need 度</h3>
+              <p className="text-xs text-muted-foreground mb-3">投稿者の困り度・重要度</p>
+              <div className="flex items-center gap-1">
+                {[1, 2, 3, 4, 5].map((level) => (
+                  <Star
+                    key={level}
+                    className={`h-6 w-6 ${level <= idea.needLevel ? "fill-amber-400 text-amber-400" : "text-muted-foreground/20"}`}
+                  />
+                ))}
+                <span className="ml-2 text-sm text-muted-foreground whitespace-nowrap">
+                  {idea.needLevel === 1 && "ちょっと気になる"}
+                  {idea.needLevel === 2 && "少し困っている"}
+                  {idea.needLevel === 3 && "まあまあ重要"}
+                  {idea.needLevel === 4 && "かなり重要"}
+                  {idea.needLevel === 5 && "めっちゃ欲しい！"}
+                </span>
+              </div>
+            </Card>
+
             <Card className="p-5 grain-overlay">
               <h3 className="font-bold text-sm mb-3">投稿者</h3>
               <Link href={`/users/${idea.author.name}`} className="flex items-center gap-3 hover:underline">

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -319,7 +319,7 @@ export interface MockIdea {
   createdAt: string;
   status: "open" | "in_progress" | "resolved";
   visibility: "public" | "private";
-  needLevel: 1 | 2 | 3 | 4 | 5;
+  needLevel: number;
 }
 
 export const mockComments = [
@@ -395,6 +395,7 @@ export const mockUserProfile = {
       createdAt: "2026-04-26T23:15:00Z",
       status: "open" as const,
       visibility: "private" as const,
+      needLevel: 3,
     },
     {
       id: "u-private-2",
@@ -408,6 +409,7 @@ export const mockUserProfile = {
       createdAt: "2026-04-27T07:45:00Z",
       status: "open" as const,
       visibility: "private" as const,
+      needLevel: 2,
     },
   ],
   notifications: [

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -19,6 +19,7 @@ export const mockIdeas = [
     createdAt: "2026-04-25T08:30:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 5,
   },
   {
     id: "2",
@@ -39,6 +40,7 @@ export const mockIdeas = [
     createdAt: "2026-04-24T18:15:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 4,
   },
   {
     id: "3",
@@ -60,6 +62,7 @@ export const mockIdeas = [
     createdAt: "2026-04-23T12:00:00Z",
     status: "in_progress" as const,
     visibility: "public" as const,
+    needLevel: 5,
   },
   {
     id: "4",
@@ -80,6 +83,7 @@ export const mockIdeas = [
     createdAt: "2026-04-22T09:45:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 4,
   },
   {
     id: "5",
@@ -100,6 +104,7 @@ export const mockIdeas = [
     createdAt: "2026-04-21T22:30:00Z",
     status: "resolved" as const,
     visibility: "public" as const,
+    needLevel: 5,
   },
   {
     id: "6",
@@ -121,6 +126,7 @@ export const mockIdeas = [
     createdAt: "2026-04-20T15:00:00Z",
     status: "open" as const,
     visibility: "private" as const,
+    needLevel: 3,
   },
   {
     id: "7",
@@ -141,6 +147,7 @@ export const mockIdeas = [
     createdAt: "2026-04-26T10:00:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 4,
   },
   {
     id: "8",
@@ -161,6 +168,7 @@ export const mockIdeas = [
     createdAt: "2026-04-26T09:15:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 3,
   },
   {
     id: "9",
@@ -182,6 +190,7 @@ export const mockIdeas = [
     createdAt: "2026-04-26T14:30:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 2,
   },
   {
     id: "10",
@@ -202,6 +211,7 @@ export const mockIdeas = [
     createdAt: "2026-04-25T19:00:00Z",
     status: "in_progress" as const,
     visibility: "public" as const,
+    needLevel: 4,
   },
   {
     id: "11",
@@ -222,6 +232,7 @@ export const mockIdeas = [
     createdAt: "2026-04-24T11:20:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 3,
   },
   {
     id: "12",
@@ -242,6 +253,7 @@ export const mockIdeas = [
     createdAt: "2026-04-23T21:30:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 5,
   },
   {
     id: "13",
@@ -262,6 +274,7 @@ export const mockIdeas = [
     createdAt: "2026-04-22T16:45:00Z",
     status: "resolved" as const,
     visibility: "public" as const,
+    needLevel: 2,
   },
   {
     id: "14",
@@ -282,6 +295,7 @@ export const mockIdeas = [
     createdAt: "2026-04-21T07:00:00Z",
     status: "open" as const,
     visibility: "public" as const,
+    needLevel: 4,
   },
 ];
 
@@ -305,6 +319,7 @@ export interface MockIdea {
   createdAt: string;
   status: "open" | "in_progress" | "resolved";
   visibility: "public" | "private";
+  needLevel: 1 | 2 | 3 | 4 | 5;
 }
 
 export const mockComments = [


### PR DESCRIPTION
## Summary
- モックデータ全14件に `needLevel`（1〜5）フィールドを追加
- `MockIdea` 型に `needLevel` を追加
- アイデア詳細ページのサイドバー上部にNeed度カードを追加（星表示＋ラベル）

## Test plan
- [x] アイデア詳細ページを開き、サイドバーにNeed度が表示されることを確認
- [x] 各needLevelのラベル（「めっちゃ欲しい！」など）が改行せず表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)