### PR TITLE
fix キャッチコピーと説明文の改行位置を文節単位に変更

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,13 +33,13 @@ export default function LandingPage() {
 
         <div className="mx-auto max-w-7xl px-4 pt-16 pb-20 sm:px-6 sm:pt-20 sm:pb-28 lg:pt-28 lg:pb-36">
           <div className="max-w-3xl mx-auto text-center">
-            <h1 className="text-5xl font-black tracking-tight sm:text-6xl lg:text-7xl animate-in fade-in slide-in-from-bottom-4 duration-700">
+            <h1 className="text-5xl font-black tracking-tight sm:text-6xl lg:text-7xl animate-in fade-in slide-in-from-bottom-4 duration-700 [word-break:auto-phrase]">
               アイディア、集まる。
               <br />
               <span className="gradient-text">未来、</span>始まる。
             </h1>
 
-            <p className="mt-6 text-lg text-muted-foreground leading-relaxed max-w-xl mx-auto animate-in fade-in slide-in-from-bottom-4 duration-700 delay-150">
+            <p className="mt-6 text-lg text-muted-foreground leading-relaxed max-w-xl mx-auto animate-in fade-in slide-in-from-bottom-4 duration-700 delay-150 [word-break:auto-phrase]">
               日常で感じるみんなの『こうなったらいいな』が集まる場所。
               相互にひらめきを育んで、漠然とした想いを、確かな形にするプラットフォーム。
             </p>


### PR DESCRIPTION
## Summary
- `h1`（キャッチコピー）と `p`（説明文）に `word-break: auto-phrase` を追加
- 幅が狭い時に文節境界で自動改行されるよう修正

## Test plan
- [x] 説明文も同様に文節単位で改行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)