### PR TITLE
fix: ダークモードでのカードホバー時のshadowをオレンジから中立色に変更

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -158,6 +158,9 @@
     transform: translateY(-2px);
     box-shadow: 0 8px 12px -8px oklch(0.68 0.17 75 / 0.35);
   }
+  .dark &:hover {
+    box-shadow: 0 8px 16px -8px oklch(0 0 0 / 0.5);
+  }
 }
 
 @utility mask-blur {


### PR DESCRIPTION
## Summary
- ダークモード時のカードホバー時のshadowがオレンジ色になっていた問題を修正
- `.dark` 環境では中立的な黒系shadowに切り替えるよう `card-hover` ユーティリティを更新

## Test plan
- [ ] ダークモードに切り替えてExploreページのカードにホバーする
- [ ] shadowがオレンジでなく暗い影になっていることを確認
- [ ] ライトモードでは従来通りのshadowが表示されることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)