### PR TITLE
feat: カード下部のコメント・作ってみたアイコンをクリックで該当セクションへ遷移

### DIFF
--- a/src/app/ideas/[id]/page.tsx
+++ b/src/app/ideas/[id]/page.tsx
@@ -190,7 +190,7 @@ export default function IdeaDetailPage() {
             </Card>
 
             {/* Comments */}
-            <div>
+            <div id="comments">
               <h2 className="font-bold text-lg mb-4 flex items-center gap-2">
                 <MessageCircle className="h-5 w-5" />
                 コメント ({comments.length})
@@ -240,7 +240,7 @@ export default function IdeaDetailPage() {
             </div>
 
             {/* Prototypes */}
-            <div>
+            <div id="prototypes">
               <h2 className="font-bold text-lg mb-4 flex items-center gap-2">
                 <Globe className="h-5 w-5 text-accent" />
                 作ってみた ({prototypes.length})

--- a/src/app/ideas/page.tsx
+++ b/src/app/ideas/page.tsx
@@ -213,14 +213,28 @@ export default function IdeasFeedPage() {
                         />
                         {getLikes(idea)}
                       </button>
-                      <span className="flex items-center gap-1 text-muted-foreground">
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          router.push(`/ideas/${idea.id}#comments`);
+                        }}
+                        className="flex items-center gap-1 hover:text-foreground transition-colors"
+                      >
                         <MessageCircle className="h-3.5 w-3.5" />
                         {idea.comments}
-                      </span>
-                      <span className="flex items-center gap-1">
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          router.push(`/ideas/${idea.id}#prototypes`);
+                        }}
+                        className="flex items-center gap-1 hover:text-accent transition-colors"
+                      >
                         <Globe className="h-3.5 w-3.5 text-accent" />
                         {protoCount}
-                      </span>
+                      </button>
                     </div>
                   </div>
                 </Card>


### PR DESCRIPTION
## Summary
- Exploreページのカード下部のコメントアイコンをクリックするとidea詳細の `#comments` セクションへ遷移
- 作ってみた（Globe）アイコンをクリックすると `#prototypes` セクションへ遷移
- idea詳細ページのコメント・作ってみたセクションに `id` アンカーを追加

## Test plan
- [ ] Exploreページでカードのコメントアイコンをクリックし、詳細ページのコメントセクションにスクロールされることを確認
- [ ] 作ってみたアイコンをクリックし、詳細ページの作ってみたセクションにスクロールされることを確認
- [ ] カード全体のリンク（タイトルクリック）は従来通り詳細ページのトップに遷移することを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)