### PR TITLE
feat: Supabase連携 + Pixivスタイルタグ検索

### DIFF
--- a/src/app/ideas/page.tsx
+++ b/src/app/ideas/page.tsx
@@ -26,6 +26,7 @@ import { mockIdeas, MockIdea, mockPrototypes } from "@/lib/mock-data";
 import { SORT_LABELS } from "@/lib/constants";
 import { formatDate } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
+import { toast } from "sonner";
 import {
   Heart,
   MessageCircle,
@@ -70,6 +71,7 @@ export default function IdeasFeedPage() {
   const [likedIds, setLikedIds] = useState<Set<string>>(new Set());
   const [localLikes, setLocalLikes] = useState<Record<string, number>>({});
   const [dbIdeas, setDbIdeas] = useState<Idea[]>([]);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
   useEffect(() => {
     supabase
@@ -78,6 +80,16 @@ export default function IdeasFeedPage() {
       .eq("visibility", "public")
       .order("created_at", { ascending: false })
       .then(({ data }) => { if (data?.length) setDbIdeas(data as Idea[]); });
+
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setCurrentUserId(user?.id ?? null);
+      if (user) {
+        supabase.from("likes").select("idea_id").eq("user_id", user.id)
+          .then(({ data }) => {
+            if (data) setLikedIds(new Set(data.map((l) => l.idea_id)));
+          });
+      }
+    });
   }, []);
 
   const allIdeas: Idea[] = dbIdeas.length > 0 ? dbIdeas : (mockIdeas as unknown as Idea[]);
@@ -114,20 +126,25 @@ export default function IdeasFeedPage() {
   const getPrototypeCount = (ideaId: string) =>
     mockPrototypes.filter((p) => p.ideaId === ideaId).length;
 
-  const handleToggleLike = (e: React.MouseEvent, idea: Idea) => {
+  const handleToggleLike = async (e: React.MouseEvent, idea: Idea) => {
     e.preventDefault();
     e.stopPropagation();
+    if (!currentUserId) { toast.error("ログインが必要です"); return; }
+    const liked = likedIds.has(idea.id);
     setLikedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(idea.id)) {
-        next.delete(idea.id);
-        setLocalLikes((l) => ({ ...l, [idea.id]: getLikes(idea) - 1 }));
-      } else {
-        next.add(idea.id);
-        setLocalLikes((l) => ({ ...l, [idea.id]: getLikes(idea) + 1 }));
-      }
+      if (liked) next.delete(idea.id);
+      else next.add(idea.id);
       return next;
     });
+    setLocalLikes((l) => ({ ...l, [idea.id]: getLikes(idea) + (liked ? -1 : 1) }));
+    if (liked) {
+      await supabase.from("likes").delete().eq("idea_id", idea.id).eq("user_id", currentUserId);
+      await supabase.from("ideas").update({ likes: Math.max(0, (idea.likes ?? 0) - 1) }).eq("id", idea.id);
+    } else {
+      await supabase.from("likes").insert({ idea_id: idea.id, user_id: currentUserId });
+      await supabase.from("ideas").update({ likes: (idea.likes ?? 0) + 1 }).eq("id", idea.id);
+    }
   };
 
   return (

--- a/src/app/ideas/page.tsx
+++ b/src/app/ideas/page.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useMemo } from "react";
 import { mockIdeas, MockIdea, mockPrototypes } from "@/lib/mock-data";
 import { SORT_LABELS } from "@/lib/constants";
 import { formatDate } from "@/lib/utils";
@@ -39,6 +40,8 @@ import {
   ArrowRight,
   Lock,
   Globe,
+  X,
+  Tag,
 } from "lucide-react";
 
 const FREE_VIEW_LIMIT = 20;
@@ -72,6 +75,7 @@ export default function IdeasFeedPage() {
   const [localLikes, setLocalLikes] = useState<Record<string, number>>({});
   const [dbIdeas, setDbIdeas] = useState<Idea[]>([]);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     supabase
@@ -94,6 +98,28 @@ export default function IdeasFeedPage() {
 
   const allIdeas: Idea[] = dbIdeas.length > 0 ? dbIdeas : (mockIdeas as unknown as Idea[]);
 
+  const allTags = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const idea of allIdeas) {
+      if (idea.visibility !== "public") continue;
+      for (const tag of idea.tags) {
+        counts[tag] = (counts[tag] ?? 0) + 1;
+      }
+    }
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([tag, count]) => ({ tag, count }));
+  }, [allIdeas]);
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) next.delete(tag);
+      else next.add(tag);
+      return next;
+    });
+  };
+
   const sorted = [...allIdeas]
     .filter((idea) => idea.visibility === "public")
     .filter((idea) => {
@@ -101,9 +127,12 @@ export default function IdeasFeedPage() {
       const q = searchQuery.toLowerCase();
       return (
         idea.title.toLowerCase().includes(q) ||
-        idea.content.toLowerCase().includes(q) ||
-        idea.tags.some((t) => t.toLowerCase().includes(q))
+        idea.content.toLowerCase().includes(q)
       );
+    })
+    .filter((idea) => {
+      if (selectedTags.size === 0) return true;
+      return [...selectedTags].every((t) => idea.tags.includes(t));
     })
     .sort((a, b) => {
       if (sort === "likes") return b.likes - a.likes;
@@ -165,11 +194,11 @@ export default function IdeasFeedPage() {
           </p>
         </div>
 
-        <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="flex flex-col sm:flex-row gap-3 mb-4">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
-              placeholder="キーワードやタグで検索..."
+              placeholder="キーワードで検索..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-10 rounded-xl"
@@ -204,9 +233,52 @@ export default function IdeasFeedPage() {
           </Select>
         </div>
 
+        {/* Tag filter — Pixiv style */}
+        <div className="mb-6">
+          <div className="flex items-center gap-2 mb-2">
+            <Tag className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground font-medium">タグで絞り込む（複数選択可）</span>
+            {selectedTags.size > 0 && (
+              <button
+                onClick={() => setSelectedTags(new Set())}
+                className="cursor-pointer text-xs text-amber-600 dark:text-amber-400 hover:underline ml-auto"
+              >
+                クリア
+              </button>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {allTags.map(({ tag, count }) => {
+              const active = selectedTags.has(tag);
+              return (
+                <button
+                  key={tag}
+                  onClick={() => toggleTag(tag)}
+                  className={`cursor-pointer inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium transition-all border ${
+                    active
+                      ? "bg-amber-500 text-white border-amber-500 shadow-sm shadow-amber-300 dark:shadow-amber-900"
+                      : "bg-transparent text-muted-foreground border-border hover:border-amber-400 hover:text-amber-600 dark:hover:text-amber-400"
+                  }`}
+                >
+                  {active && <X className="h-2.5 w-2.5" />}
+                  {tag}
+                  <span className={`${active ? "text-amber-100" : "text-muted-foreground/60"}`}>
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         <div className="flex items-center gap-4 mb-6 text-sm text-muted-foreground">
           <span>{sorted.length}件のアイディア</span>
-          <span>うち {visibleIdeas.length}件表示中</span>
+          {visibleIdeas.length < sorted.length && <span>うち {visibleIdeas.length}件表示中</span>}
+          {selectedTags.size > 0 && (
+            <span className="text-amber-600 dark:text-amber-400">
+              タグ: {[...selectedTags].join(" + ")}
+            </span>
+          )}
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -230,7 +302,12 @@ export default function IdeasFeedPage() {
                         <Badge
                           key={tag}
                           variant="outline"
-                          className="text-xs rounded-full bg-transparent"
+                          onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleTag(tag); }}
+                          className={`text-xs rounded-full cursor-pointer transition-colors ${
+                            selectedTags.has(tag)
+                              ? "bg-amber-500 text-white border-amber-500"
+                              : "bg-transparent hover:border-amber-400 hover:text-amber-600 dark:hover:text-amber-400"
+                          }`}
                         >
                           {tag}
                         </Badge>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -16,15 +16,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { mockUserProfile, mockIdeas, mockPrototypes } from "@/lib/mock-data";
+import { MockIdea } from "@/lib/mock-data";
 import { SORT_LABELS } from "@/lib/constants";
 import { IdeaCard } from "@/components/shared/idea-card";
+import { createClient } from "@/lib/supabase/client";
 import {
   Lightbulb,
   PlusCircle,
   Heart,
   MessageCircle,
-  Bell,
   Globe,
   Search,
   ChevronRight,
@@ -34,35 +34,141 @@ import {
   ExternalLink,
 } from "lucide-react";
 
-const mockLikedIdeaIds = ["3", "5", "6", "10", "12"];
+type DbIdea = {
+  id: string;
+  title: string;
+  content: string;
+  tags: string[];
+  likes: number;
+  comments: number;
+  status: "open" | "in_progress" | "resolved";
+  visibility: "public" | "private";
+  need_level: number;
+  chat_history: { question: string; answer: string }[] | null;
+  created_at: string;
+  user_id: string;
+};
+
+type DbComment = {
+  id: string;
+  idea_id: string;
+  content: string;
+  created_at: string;
+  ideas: { id: string; title: string; profiles: { name: string } | null } | null;
+};
+
+type LikedIdea = {
+  id: string;
+  title: string;
+  content: string;
+  tags: string[];
+  likes: number;
+  comments: number;
+  status: "open" | "in_progress" | "resolved";
+  visibility: "public" | "private";
+  need_level: number;
+  chat_history: { question: string; answer: string }[] | null;
+  created_at: string;
+  profiles: { name: string; avatar_url: string | null } | null;
+};
+
+function toMockIdea(idea: DbIdea, authorName: string, authorAvatar: string): MockIdea {
+  return {
+    id: idea.id,
+    title: idea.title,
+    content: idea.content,
+    chatHistory: idea.chat_history ?? [],
+    tags: idea.tags ?? [],
+    likes: idea.likes ?? 0,
+    comments: idea.comments ?? 0,
+    author: { name: authorName, avatar: authorAvatar },
+    createdAt: idea.created_at,
+    status: idea.status,
+    visibility: idea.visibility,
+    needLevel: idea.need_level ?? 3,
+  };
+}
+
+function likedToMockIdea(idea: LikedIdea): MockIdea {
+  const authorName = idea.profiles?.name ?? "Unknown";
+  return {
+    id: idea.id,
+    title: idea.title,
+    content: idea.content,
+    chatHistory: idea.chat_history ?? [],
+    tags: idea.tags ?? [],
+    likes: idea.likes ?? 0,
+    comments: idea.comments ?? 0,
+    author: { name: authorName, avatar: authorName.charAt(0).toUpperCase() },
+    createdAt: idea.created_at,
+    status: idea.status,
+    visibility: idea.visibility,
+    needLevel: idea.need_level ?? 3,
+  };
+}
 
 export default function ProfilePage() {
-  const {
-    name,
-    avatar,
-    totalIdeas,
-    totalLikes,
-    totalComments,
-    totalContributions,
-    ideas,
-    notifications,
-    myComments,
-  } = mockUserProfile;
+  const supabase = createClient();
+  const [profile, setProfile] = useState<{ name: string; avatar_url: string | null } | null>(null);
+  const [ideas, setIdeas] = useState<DbIdea[]>([]);
+  const [likedIdeas, setLikedIdeas] = useState<LikedIdea[]>([]);
+  const [myComments, setMyComments] = useState<DbComment[]>([]);
+  const [loading, setLoading] = useState(true);
   const [showPrivate, setShowPrivate] = useState(false);
   const [sort, setSort] = useState("likes");
   const [tagFilter, setTagFilter] = useState("");
 
-  const likedIdeas = mockIdeas.filter(
-    (i) => mockLikedIdeaIds.includes(i.id) && i.visibility === "public",
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) { setLoading(false); return; }
+
+      const [profileRes, ideasRes, commentsRes, likedRes] = await Promise.all([
+        supabase.from("profiles").select("name, avatar_url").eq("id", user.id).single(),
+        supabase.from("ideas").select("*").eq("user_id", user.id).order("created_at", { ascending: false }),
+        supabase.from("comments")
+          .select("*, ideas(id, title, profiles(name))")
+          .eq("user_id", user.id)
+          .order("created_at", { ascending: false }),
+        supabase.from("likes")
+          .select("ideas(id, title, content, tags, likes, comments, status, visibility, need_level, chat_history, created_at, profiles(name, avatar_url))")
+          .eq("user_id", user.id),
+      ]);
+
+      if (profileRes.data) setProfile(profileRes.data);
+      if (ideasRes.data) setIdeas(ideasRes.data as DbIdea[]);
+      if (commentsRes.data) setMyComments(commentsRes.data as DbComment[]);
+      if (likedRes.data) {
+        const liked = likedRes.data
+          .map((l: any) => l.ideas)
+          .filter(Boolean) as LikedIdea[];
+        setLikedIdeas(liked);
+      }
+      setLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  const name = profile?.name ?? "ユーザー";
+  const avatar = (profile?.name ?? "U").charAt(0).toUpperCase();
+  const totalIdeas = ideas.length;
+  const totalLikes = ideas.reduce((sum, i) => sum + (i.likes ?? 0), 0);
+  const totalComments = ideas.reduce((sum, i) => sum + (i.comments ?? 0), 0);
+
+  const mockIdeasForCard = useMemo(
+    () => ideas.map((i) => toMockIdea(i, name, avatar)),
+    [ideas, name, avatar],
   );
-  const myPrototypes = mockPrototypes.filter(
-    (p) => p.author.name === "ユーザー",
+
+  const likedIdeasForCard = useMemo(
+    () => likedIdeas.map(likedToMockIdea),
+    [likedIdeas],
   );
 
   const topTags = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const idea of ideas) {
-      for (const tag of idea.tags) {
+      for (const tag of idea.tags ?? []) {
         counts[tag] = (counts[tag] ?? 0) + 1;
       }
     }
@@ -74,8 +180,8 @@ export default function ProfilePage() {
 
   const filteredIdeas = useMemo(() => {
     let filtered = showPrivate
-      ? [...ideas]
-      : ideas.filter((i) => i.visibility === "public");
+      ? [...mockIdeasForCard]
+      : mockIdeasForCard.filter((i) => i.visibility === "public");
     if (tagFilter) {
       filtered = filtered.filter((i) =>
         i.tags.some((t) => t.toLowerCase().includes(tagFilter.toLowerCase())),
@@ -85,7 +191,28 @@ export default function ProfilePage() {
       if (sort === "likes") return b.likes - a.likes;
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
-  }, [ideas, showPrivate, tagFilter, sort]);
+  }, [mockIdeasForCard, showPrivate, tagFilter, sort]);
+
+  if (loading) {
+    return (
+      <div className="min-h-full flex items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="min-h-full flex items-center justify-center">
+        <Card className="p-8 text-center">
+          <p className="text-muted-foreground mb-4">ログインが必要です</p>
+          <Link href="/post">
+            <Button className="rounded-full gradient-amber">ログインする</Button>
+          </Link>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-full px-4 sm:px-6">
@@ -117,10 +244,6 @@ export default function ProfilePage() {
                   <MessageCircle className="h-3.5 w-3.5" /> {totalComments}{" "}
                   comments
                 </span>
-                <span className="text-xs text-muted-foreground flex items-center gap-1">
-                  <Globe className="h-3.5 w-3.5 text-accent" />{" "}
-                  {myPrototypes.length} apps
-                </span>
               </div>
             </div>
             <Link href="/post">
@@ -149,25 +272,11 @@ export default function ProfilePage() {
               Liked
             </TabsTrigger>
             <TabsTrigger
-              value="apps"
-              className="rounded-full data-[state=active]:bg-amber-100 data-[state=active]:text-amber-900 dark:data-[state=active]:bg-amber-900/30 dark:data-[state=active]:text-amber-200 px-4 py-2 text-sm"
-            >
-              <Globe className="h-4 w-4 mr-1.5" />
-              My Apps
-            </TabsTrigger>
-            <TabsTrigger
               value="comments"
               className="rounded-full data-[state=active]:bg-amber-100 data-[state=active]:text-amber-900 dark:data-[state=active]:bg-amber-900/30 dark:data-[state=active]:text-amber-200 px-4 py-2 text-sm"
             >
               <MessageCircle className="h-4 w-4 mr-1.5" />
               Comments
-            </TabsTrigger>
-            <TabsTrigger
-              value="feedback"
-              className="rounded-full data-[state=active]:bg-amber-100 data-[state=active]:text-amber-900 dark:data-[state=active]:bg-amber-900/30 dark:data-[state=active]:text-amber-200 px-4 py-2 text-sm"
-            >
-              <Bell className="h-4 w-4 mr-1.5" />
-              My Feedback
             </TabsTrigger>
           </TabsList>
 
@@ -246,87 +355,30 @@ export default function ProfilePage() {
                 <IdeaCard key={idea.id} idea={idea} />
               ))}
             </div>
+            {filteredIdeas.length === 0 && (
+              <Card className="p-12 text-center grain-overlay">
+                <Lightbulb className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+                <p className="text-muted-foreground">まだアイディアがありません</p>
+              </Card>
+            )}
           </TabsContent>
 
           {/* Liked Ideas */}
           <TabsContent value="liked" className="space-y-4">
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">
-                {likedIdeas.length}件のいいね
+                {likedIdeasForCard.length}件のいいね
               </span>
             </div>
             <div className="gap-3 flex flex-col">
-              {likedIdeas.map((idea) => (
+              {likedIdeasForCard.map((idea) => (
                 <IdeaCard key={idea.id} idea={idea} showAuthor />
               ))}
             </div>
-          </TabsContent>
-
-          {/* My Apps */}
-          <TabsContent value="apps" className="space-y-4">
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-sm text-muted-foreground">
-                {myPrototypes.length}件のプロトタイプ
-              </span>
-            </div>
-            {myPrototypes.length > 0 ? (
-              myPrototypes.map((proto) => (
-                <Card key={proto.id} className="p-5 grain-overlay">
-                  <div className="flex items-start gap-4">
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-accent/10">
-                      <Globe className="h-5 w-5 text-accent" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <Link
-                        href={`/ideas/${proto.ideaId}`}
-                        className="font-bold hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
-                      >
-                        {proto.title}
-                      </Link>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        {proto.description}
-                      </p>
-                      <div className="flex items-center gap-3 mt-3">
-                        <span className="text-xs text-muted-foreground flex items-center gap-1">
-                          <Heart className="h-3 w-3 text-rose-500" />{" "}
-                          {proto.likes}
-                        </span>
-                        <span className="text-xs text-muted-foreground flex items-center gap-1">
-                          <MessageCircle className="h-3 w-3" /> コメント
-                        </span>
-                      </div>
-                      <div className="flex gap-2 mt-3">
-                        {proto.githubUrl && (
-                          <a
-                            href={proto.githubUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 text-xs font-medium bg-muted px-3 py-1.5 rounded-full hover:bg-muted/80 transition-colors"
-                          >
-                            <GitFork className="h-3.5 w-3.5" /> GitHub
-                          </a>
-                        )}
-                        {proto.demoUrl && (
-                          <a
-                            href={proto.demoUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 text-xs font-medium bg-accent text-accent-foreground px-3 py-1.5 rounded-full hover:opacity-90 transition-opacity"
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" /> Demo
-                          </a>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              ))
-            ) : (
+            {likedIdeasForCard.length === 0 && (
               <Card className="p-12 text-center grain-overlay">
-                <Globe className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                <p className="text-muted-foreground">
-                  まだプロトタイプがありません
-                </p>
+                <Heart className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+                <p className="text-muted-foreground">まだいいねしたアイディアがありません</p>
               </Card>
             )}
           </TabsContent>
@@ -339,8 +391,8 @@ export default function ProfilePage() {
               </span>
             </div>
             <div className="gap-3 flex flex-col">
-              {myComments.map((comment, i) => (
-                <Link key={i} href={`/ideas/${comment.ideaId}`}>
+              {myComments.map((comment) => (
+                <Link key={comment.id} href={`/ideas/${comment.idea_id}`}>
                   <Card className="p-4 card-hover cursor-pointer grain-overlay">
                     <div className="flex items-start gap-3">
                       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
@@ -348,19 +400,17 @@ export default function ProfilePage() {
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="text-xs text-muted-foreground mb-1">
-                          「{comment.ideaTitle}」
-                          <span className="text-muted-foreground/60">
-                            {" "}
-                            by {comment.ideaAuthor}
-                          </span>{" "}
+                          「{comment.ideas?.title ?? "アイディア"}」
+                          {comment.ideas?.profiles?.name && (
+                            <span className="text-muted-foreground/60">
+                              {" "}by {comment.ideas.profiles.name}
+                            </span>
+                          )}{" "}
                           にコメント
                         </p>
                         <p className="text-sm leading-relaxed line-clamp-2">
                           &ldquo;{comment.content}&rdquo;
                         </p>
-                        <span className="text-xs text-muted-foreground mt-1.5 block">
-                          {comment.time}
-                        </span>
                       </div>
                       <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
                     </div>
@@ -368,66 +418,12 @@ export default function ProfilePage() {
                 </Link>
               ))}
             </div>
-          </TabsContent>
-
-          {/* My Feedback */}
-          <TabsContent value="feedback" className="space-y-4">
-            {notifications.map((notif, i) => (
-              <Card key={i} className="p-4 grain-overlay">
-                <div className="flex items-start gap-3">
-                  <div
-                    className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${
-                      notif.type === "like"
-                        ? "bg-rose-100 text-rose-500 dark:bg-rose-900/30 dark:text-rose-400"
-                        : notif.type === "comment"
-                          ? "bg-blue-100 text-blue-500 dark:bg-blue-900/30 dark:text-blue-400"
-                          : "bg-green-100 text-green-500 dark:bg-green-900/30 dark:text-green-400"
-                    }`}
-                  >
-                    {notif.type === "like" && <Heart className="h-4 w-4" />}
-                    {notif.type === "comment" && (
-                      <MessageCircle className="h-4 w-4" />
-                    )}
-                    {notif.type === "prototype" && (
-                      <Globe className="h-4 w-4" />
-                    )}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm leading-relaxed">
-                      {notif.type === "like" && (
-                        <>
-                          <span className="font-bold">
-                            {notif.count}件のいいね
-                          </span>{" "}
-                          がつきました
-                        </>
-                      )}
-                      {notif.type === "comment" && (
-                        <>
-                          <span className="font-bold">
-                            {notif.count}件のコメント
-                          </span>{" "}
-                          がつきました
-                        </>
-                      )}
-                      {notif.type === "prototype" && (
-                        <>
-                          あなたのアイディアに{" "}
-                          <span className="font-bold">プロトタイプ</span>{" "}
-                          が投稿されました
-                        </>
-                      )}
-                    </p>
-                    <p className="text-xs text-muted-foreground mt-1 truncate">
-                      「{notif.ideaTitle}」
-                    </p>
-                    <span className="text-xs text-muted-foreground mt-1 block">
-                      {notif.time}
-                    </span>
-                  </div>
-                </div>
+            {myComments.length === 0 && (
+              <Card className="p-12 text-center grain-overlay">
+                <MessageCircle className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+                <p className="text-muted-foreground">まだコメントがありません</p>
               </Card>
-            ))}
+            )}
           </TabsContent>
         </Tabs>
       </div>

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,30 +1,116 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { mockIdeas, mockPrototypes } from "@/lib/mock-data";
+import { MockIdea } from "@/lib/mock-data";
 import { IdeaCard } from "@/components/shared/idea-card";
+import { createClient } from "@/lib/supabase/client";
 import {
   Lightbulb,
   Heart,
-  MessageCircle,
   ArrowLeft,
   Globe,
 } from "lucide-react";
 
+type DbIdea = {
+  id: string;
+  title: string;
+  content: string;
+  tags: string[];
+  likes: number;
+  comments: number;
+  status: "open" | "in_progress" | "resolved";
+  visibility: "public" | "private";
+  need_level: number;
+  chat_history: { question: string; answer: string }[] | null;
+  created_at: string;
+  user_id: string;
+};
+
+function toMockIdea(idea: DbIdea, authorName: string, authorAvatar: string): MockIdea {
+  return {
+    id: idea.id,
+    title: idea.title,
+    content: idea.content,
+    chatHistory: idea.chat_history ?? [],
+    tags: idea.tags ?? [],
+    likes: idea.likes ?? 0,
+    comments: idea.comments ?? 0,
+    author: { name: authorName, avatar: authorAvatar },
+    createdAt: idea.created_at,
+    status: idea.status,
+    visibility: idea.visibility,
+    needLevel: idea.need_level ?? 3,
+  };
+}
+
 export default function UserProfilePage() {
   const params = useParams();
   const name = decodeURIComponent(params.id as string);
+  const supabase = createClient();
 
-  const userIdeas = mockIdeas.filter(
-    (idea) => idea.author.name === name && idea.visibility === "public"
-  );
-  const userPrototypes = mockPrototypes.filter((p) => p.author.name === name);
-  const totalLikes = userIdeas.reduce((sum, i) => sum + i.likes, 0);
+  const [profile, setProfile] = useState<{ id: string; name: string; avatar_url: string | null } | null>(null);
+  const [ideas, setIdeas] = useState<MockIdea[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data: profileData } = await supabase
+        .from("profiles")
+        .select("id, name, avatar_url")
+        .eq("name", name)
+        .maybeSingle();
+
+      if (!profileData) { setLoading(false); return; }
+      setProfile(profileData);
+
+      const { data: ideasData } = await supabase
+        .from("ideas")
+        .select("*")
+        .eq("user_id", profileData.id)
+        .eq("visibility", "public")
+        .order("created_at", { ascending: false });
+
+      if (ideasData) {
+        const authorAvatar = profileData.name.charAt(0).toUpperCase();
+        setIdeas(ideasData.map((i) => toMockIdea(i as DbIdea, profileData.name, authorAvatar)));
+      }
+      setLoading(false);
+    };
+    fetchData();
+  }, [name]);
+
+  const totalLikes = ideas.reduce((sum, i) => sum + i.likes, 0);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="min-h-screen py-8 px-4 sm:px-6">
+        <div className="mx-auto max-w-4xl">
+          <Link href="/ideas">
+            <Button variant="ghost" size="sm" className="rounded-full gap-1 mb-6 -ml-3 text-muted-foreground">
+              <ArrowLeft className="h-4 w-4" /> 戻る
+            </Button>
+          </Link>
+          <Card className="p-12 text-center grain-overlay">
+            <p className="text-muted-foreground">ユーザーが見つかりませんでした</p>
+          </Card>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen py-8 px-4 sm:px-6">
@@ -35,34 +121,31 @@ export default function UserProfilePage() {
           </Button>
         </Link>
 
-        {/* Profile Header — same style as MyPage */}
+        {/* Profile Header */}
         <Card className="p-6 sm:p-8 mb-8 grain-overlay overflow-hidden relative">
           <div className="absolute top-0 left-0 right-0 h-32 gradient-amber rounded-t-xl opacity-20 dark:opacity-10" />
           <div className="relative flex flex-col sm:flex-row sm:items-center gap-5">
             <Avatar className="h-20 w-20 ring-4 ring-background shadow-lg">
               <AvatarFallback className="text-2xl font-black bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300">
-                {name.charAt(0)}
+                {profile.name.charAt(0)}
               </AvatarFallback>
             </Avatar>
             <div className="flex-1">
-              <h1 className="text-2xl font-black tracking-tight">{name}</h1>
+              <h1 className="text-2xl font-black tracking-tight">{profile.name}</h1>
               <p className="text-sm text-muted-foreground mt-0.5">アイディアハブメンバー</p>
               <div className="flex items-center gap-4 mt-3 flex-wrap">
                 <span className="text-xs text-muted-foreground flex items-center gap-1">
-                  <Lightbulb className="h-3.5 w-3.5 text-amber-500" /> {userIdeas.length} ideas
+                  <Lightbulb className="h-3.5 w-3.5 text-amber-500" /> {ideas.length} ideas
                 </span>
                 <span className="text-xs text-muted-foreground flex items-center gap-1">
                   <Heart className="h-3.5 w-3.5 text-rose-500" /> {totalLikes} likes
-                </span>
-                <span className="text-xs text-muted-foreground flex items-center gap-1">
-                  <Globe className="h-3.5 w-3.5 text-accent" /> {userPrototypes.length} apps
                 </span>
               </div>
             </div>
           </div>
         </Card>
 
-        {/* Tabs — same style as MyPage */}
+        {/* Tabs */}
         <Tabs defaultValue="ideas" className="space-y-6">
           <TabsList className="w-full justify-start rounded-full p-1 bg-muted h-auto gap-0 flex-wrap">
             <TabsTrigger
@@ -72,65 +155,20 @@ export default function UserProfilePage() {
               <Lightbulb className="h-4 w-4 mr-1.5" />
               Ideas
             </TabsTrigger>
-            <TabsTrigger
-              value="apps"
-              className="rounded-full data-[state=active]:bg-amber-100 data-[state=active]:text-amber-900 dark:data-[state=active]:bg-amber-900/30 dark:data-[state=active]:text-amber-200 px-4 py-2 text-sm"
-            >
-              <Globe className="h-4 w-4 mr-1.5" />
-              Apps
-            </TabsTrigger>
           </TabsList>
 
-          {/* Ideas */}
           <TabsContent value="ideas" className="space-y-4">
             <div className="flex items-center justify-between">
-              <span className="text-sm text-muted-foreground">{userIdeas.length}件のアイディア</span>
+              <span className="text-sm text-muted-foreground">{ideas.length}件のアイディア</span>
             </div>
-            {userIdeas.length > 0 ? (
-              userIdeas.map((idea) => (
+            {ideas.length > 0 ? (
+              ideas.map((idea) => (
                 <IdeaCard key={idea.id} idea={idea} showAuthor={false} />
               ))
             ) : (
               <Card className="p-12 text-center grain-overlay">
                 <Lightbulb className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
                 <p className="text-muted-foreground">まだ公開アイディアがありません</p>
-              </Card>
-            )}
-          </TabsContent>
-
-          {/* Apps */}
-          <TabsContent value="apps" className="space-y-4">
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-muted-foreground">{userPrototypes.length}件のプロトタイプ</span>
-            </div>
-            {userPrototypes.length > 0 ? (
-              userPrototypes.map((proto) => (
-                <Card key={proto.id} className="p-5 grain-overlay">
-                  <div className="flex items-start gap-4">
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-accent/10">
-                      <Globe className="h-5 w-5 text-accent" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <Link href={`/ideas/${proto.ideaId}`} className="font-bold hover:text-amber-600 dark:hover:text-amber-400 transition-colors">
-                        {proto.title}
-                      </Link>
-                      <p className="text-sm text-muted-foreground mt-1">{proto.description}</p>
-                      <div className="flex items-center gap-3 mt-3">
-                        <span className="text-xs text-muted-foreground flex items-center gap-1">
-                          <Heart className="h-3 w-3 text-rose-500" /> {proto.likes}
-                        </span>
-                        <span className="text-xs text-muted-foreground flex items-center gap-1">
-                          <MessageCircle className="h-3 w-3" /> コメント
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              ))
-            ) : (
-              <Card className="p-12 text-center grain-overlay">
-                <Globe className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                <p className="text-muted-foreground">まだプロトタイプがありません</p>
               </Card>
             )}
           </TabsContent>


### PR DESCRIPTION
## Summary

- アイディア詳細ページ（`/ideas/[id]`）をSupabase連携（ideas・comments・likesテーブル）
- 残りページ（一覧・プロフィール・ユーザー）もSupabase連携
- Pixivスタイルのタグ検索UIを実装

## 変更内容

### Supabase連携
- `/ideas/[id]`: アイデア・コメント・いいねをDB取得、いいねはリアルタイム更新
- `/ideas`: いいねをDBに永続化、ログイン状態でいいね済みIDを初期取得
- `/profile`: プロフィール・自分のアイデア・いいね一覧・コメントをDB取得
- `/users/[id]`: 名前でプロフィールを検索し、そのユーザーの公開アイデアをDB取得

### タグ検索
- 全タグを件数付きピルで表示（多い順）
- 複数選択でANDフィルター（Pixivと同じ挙動）
- カード内タグもクリックで絞り込み可能
- 選択中タグはアンバー色でハイライト、Xで個別削除・クリアボタンで一括解除

## Test plan

- [ ] ログイン状態でいいねが永続化されること
- [ ] タグを複数選択してANDフィルターが効くこと
- [ ] プロフィールページに自分のアイデア・いいね・コメントが表示されること
- [ ] ユーザーページに該当ユーザーのアイデアが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)