### PR TITLE
fix: ログイン済みでもMy Pageにアクセスできない問題を修正

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -110,6 +110,7 @@ function likedToMockIdea(idea: LikedIdea): MockIdea {
 export default function ProfilePage() {
   const supabase = createClient();
   const [profile, setProfile] = useState<{ name: string; avatar_url: string | null } | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const [ideas, setIdeas] = useState<DbIdea[]>([]);
   const [likedIdeas, setLikedIdeas] = useState<LikedIdea[]>([]);
   const [myComments, setMyComments] = useState<DbComment[]>([]);
@@ -121,7 +122,8 @@ export default function ProfilePage() {
   useEffect(() => {
     const fetchData = async () => {
       const { data: { user } } = await supabase.auth.getUser();
-      if (!user) { setLoading(false); return; }
+      if (!user) { setIsAuthenticated(false); setLoading(false); return; }
+      setIsAuthenticated(true);
 
       const [profileRes, ideasRes, commentsRes, likedRes] = await Promise.all([
         supabase.from("profiles").select("name, avatar_url").eq("id", user.id).single(),
@@ -201,7 +203,7 @@ export default function ProfilePage() {
     );
   }
 
-  if (!profile) {
+  if (isAuthenticated === false) {
     return (
       <div className="min-h-full flex items-center justify-center">
         <Card className="p-8 text-center">


### PR DESCRIPTION
## Summary

ログイン済みでも My Page に「ログインが必要です」と表示されるバグを修正。

## 原因

`profile` が `null` かどうかだけで判定していたため、ログイン済みでも `profiles` テーブルにレコードがない場合に未ログインと誤判定していた。

## 修正内容

- `isAuthenticated` を別 state で管理し、`auth.getUser()` の結果で明示的にセット
- `isAuthenticated === false` のときだけログイン画面を表示するよう変更

## Test plan

- [ ] ログイン済みで `/profile` にアクセスするとプロフィールページが表示されること
- [ ] 未ログインで `/profile` にアクセスするとログイン案内が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)