### PR TITLE
feat: ログイン機能を実装

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,35 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/profile";
+
+  if (code) {
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          },
+        },
+      }
+    );
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/auth/login?error=true`);
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card } from "@/components/ui/card";
+import { createClient } from "@/lib/supabase/client";
+import { Sparkles, Mail, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+export default function LoginPage() {
+  const supabase = createClient();
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim()) return;
+    setLoading(true);
+    setError("");
+    const { error } = await supabase.auth.signInWithOtp({
+      email: email.trim(),
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    setLoading(false);
+    if (error) {
+      setError("送信に失敗しました。もう一度お試しください。");
+    } else {
+      setSent(true);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <div className="inline-flex h-14 w-14 items-center justify-center rounded-2xl gradient-amber shadow-lg shadow-amber-500/25 mb-4">
+            <Sparkles className="h-7 w-7 text-white" />
+          </div>
+          <h1 className="text-2xl font-black tracking-tight">Needia</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            ログインしてアイディアをシェアしよう
+          </p>
+        </div>
+
+        <Card className="p-6 grain-overlay">
+          {sent ? (
+            <div className="text-center py-4">
+              <Mail className="h-10 w-10 text-amber-500 mx-auto mb-3" />
+              <h2 className="font-bold text-lg mb-2">メールを送信しました</h2>
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium">{email}</span> にログインリンクを送りました。
+                メールを確認してリンクをクリックしてください。
+              </p>
+              <button
+                onClick={() => setSent(false)}
+                className="mt-4 text-xs text-muted-foreground hover:underline cursor-pointer"
+              >
+                別のメールアドレスで試す
+              </button>
+            </div>
+          ) : (
+            <form onSubmit={handleLogin} className="space-y-4">
+              <div>
+                <label className="text-sm font-medium mb-1.5 block">
+                  メールアドレス
+                </label>
+                <Input
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="rounded-xl"
+                  required
+                />
+              </div>
+              {error && (
+                <p className="text-sm text-destructive">{error}</p>
+              )}
+              <Button
+                type="submit"
+                disabled={loading || !email.trim()}
+                className="w-full rounded-full gradient-amber"
+              >
+                {loading ? "送信中..." : "ログインリンクを送る"}
+              </Button>
+              <p className="text-xs text-center text-muted-foreground">
+                メールアドレスにログインリンクを送ります。
+                パスワード不要です。
+              </p>
+            </form>
+          )}
+        </Card>
+
+        <div className="mt-4 text-center">
+          <Link href="/" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors">
+            <ArrowLeft className="h-3.5 w-3.5" /> トップに戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -208,7 +208,7 @@ export default function ProfilePage() {
       <div className="min-h-full flex items-center justify-center">
         <Card className="p-8 text-center">
           <p className="text-muted-foreground mb-4">ログインが必要です</p>
-          <Link href="/post">
+          <Link href="/auth/login">
             <Button className="rounded-full gradient-amber">ログインする</Button>
           </Link>
         </Card>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { createClient } from "@/lib/supabase/client";
 import {
   Lightbulb,
   Menu,
@@ -22,6 +23,7 @@ import {
   Moon,
   LogOut,
   Sparkles,
+  LogIn,
 } from "lucide-react";
 
 const navLinks = [
@@ -33,8 +35,27 @@ const navLinks = [
 
 export function Header() {
   const pathname = usePathname();
+  const router = useRouter();
   const { theme, setTheme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [userInitial, setUserInitial] = useState<string | null>(null);
+  const supabase = createClient();
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) {
+        supabase.from("profiles").select("name").eq("id", user.id).single()
+          .then(({ data }) => setUserInitial(data?.name?.charAt(0).toUpperCase() ?? "U"));
+      }
+    });
+  }, []);
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    setUserInitial(null);
+    router.push("/");
+    router.refresh();
+  };
 
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/";
@@ -93,33 +114,42 @@ export function Header() {
             </Button>
           </Link>
 
-          <DropdownMenu>
-            <DropdownMenuTrigger>
-              <Avatar className="h-8 w-8 ring-2 ring-amber-200 dark:ring-amber-800 cursor-pointer">
-                <AvatarFallback className="bg-amber-100 text-amber-700 text-xs font-bold dark:bg-amber-900 dark:text-amber-300">
-                  U
-                </AvatarFallback>
-              </Avatar>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuItem>
-                <Link href="/profile" className="flex items-center gap-2 cursor-pointer">
-                  <User className="h-4 w-4" />
-                  My Page
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                <Link href="/post" className="flex items-center gap-2 cursor-pointer">
-                  <Lightbulb className="h-4 w-4" />
-                  新規投稿
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem className="gap-2 text-muted-foreground cursor-pointer">
-                <LogOut className="h-4 w-4" />
-                Sign Out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {userInitial ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger>
+                <Avatar className="h-8 w-8 ring-2 ring-amber-200 dark:ring-amber-800 cursor-pointer">
+                  <AvatarFallback className="bg-amber-100 text-amber-700 text-xs font-bold dark:bg-amber-900 dark:text-amber-300">
+                    {userInitial}
+                  </AvatarFallback>
+                </Avatar>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem>
+                  <Link href="/profile" className="flex items-center gap-2 cursor-pointer">
+                    <User className="h-4 w-4" />
+                    My Page
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <Link href="/post" className="flex items-center gap-2 cursor-pointer">
+                    <Lightbulb className="h-4 w-4" />
+                    新規投稿
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleSignOut} className="gap-2 text-muted-foreground cursor-pointer">
+                  <LogOut className="h-4 w-4" />
+                  Sign Out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Link href="/auth/login">
+              <Button variant="outline" size="sm" className="rounded-full gap-1.5">
+                <LogIn className="h-3.5 w-3.5" />
+                ログイン
+              </Button>
+            </Link>
+          )}
         </div>
 
         {/* Mobile Nav */}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,37 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

アプリにログイン機能がなかったため、Supabaseのメールマジックリンク認証を実装。

## 変更内容

- **`/auth/login`**: メールアドレスを入力してログインリンクを送信するページ
- **`/auth/callback`**: Supabaseからのコールバックを受けてセッションを確立するAPIルート
- **`middleware.ts`**: 全ページでセッションを自動更新（これがないと `auth.getUser()` が常にnullを返す根本原因）
- **ヘッダー**: ログイン済みならアバター＋ドロップダウン、未ログインなら「ログイン」ボタンを表示。Sign Outも動作するように修正
- **プロフィールページ**: 「ログインする」ボタンの遷移先を `/auth/login` に修正

## ログインの流れ

1. `/auth/login` でメールアドレスを入力
2. Supabaseからマジックリンクがメールで届く
3. リンクをクリック → `/auth/callback` でセッション確立 → `/profile` へリダイレクト

## Test plan

- [ ] `/auth/login` でメールを入力して送信できること
- [ ] メールのリンクをクリックするとログイン状態になり `/profile` に遷移すること
- [ ] ヘッダーにアバターが表示されること
- [ ] Sign Out後にトップページに遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)